### PR TITLE
8 タグからの絞り込み検索

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -27,16 +27,29 @@ class AppServiceProvider extends ServiceProvider
     {
         view()->composer('*', function($view) {
             // {{メモデータを取得}}
-            $memos = Memo::select('memos.*')
-                ->where('user_id', '=', \Auth::id())
-                ->whereNull('deleted_at')
-                ->orderBy('updated_at', 'DESC')
-                ->get();
+            $query_tag = \Request::query('tag');
+            if(!empty($query_tag)) {
+                $memos = Memo::select('memos.*')
+                    ->leftJoin('memo_tags', 'memo_tags.memo_id', '=', 'memos.id')
+                    ->where('memo_tags.tag_id', '=', $query_tag)
+                    ->where('user_id', '=', \Auth::id())
+                    ->whereNull('deleted_at')
+                    ->orderBy('updated_at', 'DESC')
+                    ->get();
+            } else {
+                $memos = Memo::select('memos.*')
+                    ->where('user_id', '=', \Auth::id())
+                    ->whereNull('deleted_at')
+                    ->orderBy('updated_at', 'DESC')
+                    ->get();
+            };
 
+            // {{タグデータを取得}}
             $tags = Tag::where('user_id', '=', \Auth::id())
                 ->whereNull('deleted_at')
                 ->orderBy('id', 'DESC')
                 ->get();
+
             $view->with('memos', $memos)->with('tags', $tags);
         });
     }


### PR DESCRIPTION
絞り込みの条件分岐を追記
  memo_tagsテーブルのmemo_idとmemosテーブルのidが等しければ結合する
  $query_tagがmemo_tagsテーブルのtag_idと同じである
  ログインidとuser_idが同じである
  deleted_atがNULLである
以上の場合
  updated_atを降順に並べ、
  表示する

![before_8_logicスクリーンショット 2022-01-28 112830](https://user-images.githubusercontent.com/89558052/151476903-36b51b86-9d85-4a28-a050-20092b01329f.png)

new tag4 を選択する

![after_8_logicスクリーンショット 2022-01-28 112902](https://user-images.githubusercontent.com/89558052/151476934-d405f141-8847-46f7-b093-0bfd99563189.png)

new tag4 (tag_id=5) タグと一致したものを表示