### PR TITLE
9 新規作成にバリデーション機能を追加

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -36,6 +36,7 @@ class HomeController extends Controller
     public function store(Request $request)
     {
         $posts = $request->all();
+        $request->validate(['content' => 'required']);
 
         // {{ トランザクション }}
         DB::transaction(function () use ($posts) {
@@ -78,6 +79,7 @@ class HomeController extends Controller
     public function update(Request $request)
     {
         $posts = $request->all();
+        $request->validate(['content' => 'required']);
 
         DB::transaction(function() use($posts) {
             Memo::where('id', $posts['memo_id'])->update(['content' => $posts['content']]);

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -7,6 +7,9 @@
         <div class="form-group">
             <textarea class="form-control" name="content" rows="3" placeholder="ここにメモを入力"></textarea>
         </div>
+        @error('content')
+            <div class='alert alert-danger mt-2 mb-2'>メモ内容を入力してください</div>
+        @enderror
         @foreach($tags as $tag)
             <div class="form-check form-check-inline mb-3">
                 <input type="checkbox" class="form-check-input" name="tags[]" id="{{$tag['id']}}" value="{{$tag['id']}}">

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -17,6 +17,9 @@
             {{$edit_memo[0]['content']}}
             </textarea>
         </div>
+        @error('content')
+           <div class='alert alert-danger mt-2 mb-2'>メモ内容を入力してください</div>
+        @enderror
         @foreach($tags as $tag)
         <div class="form-check form-check-inline mb-3">
             <input type="checkbox" class="form-check-input" name="tags[]" id="{{$tag['id']}}" value="{{$tag['id']}}" {{in_array($tag['id'], $include_tags) ? 'checked' : ''}}>


### PR DESCRIPTION
@errorを使用
  新規メモ作成、メモ編集時に空の投稿をはじくように追記

![before_9_validateスクリーンショット 2022-01-28 152349](https://user-images.githubusercontent.com/89558052/151498295-1cb07b3d-b08c-40b9-b7c3-60f58046b7b3.png)

新規メモを空で保存した場合
![after_9_validate_new_memoスクリーンショット 2022-01-28 152447](https://user-images.githubusercontent.com/89558052/151498357-1dc59652-680a-4ee7-ad2b-98c716df8392.png)

既存メモを削除し空の状態で保存した場合、元のメモ情報を復元しエラーを表示
![after_9_validate_edit_memoスクリーンショット 2022-01-28 152529](https://user-images.githubusercontent.com/89558052/151498418-ba027b74-b8e7-418f-919a-a31bac48cf76.png)

