### PR TITLE
11 Font Awesome を導入する

### DIFF
--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('javascript')
-    <script src="/js/confirm.js"></script>
+<script src="/js/confirm.js"></script>
 @endsection
 @section('content')
 <div class="card">
@@ -9,7 +9,7 @@
         <form class="card-body" id="delete-form" action="{{route('destroy')}}" method="POST">
             @csrf
             <input type="hidden" name="memo_id" value="{{$edit_memo[0]['id']}}">
-            <button type="submit" onclick="deleteHandle(event);">削除</button>
+            <i class="fas fa-trash" onclick="deleteHandle(event);"></i>
         </form>
     </div>
     <form class="card-body" action="{{route('update')}}" method="POST">
@@ -21,7 +21,7 @@
             </textarea>
         </div>
         @error('content')
-           <div class='alert alert-danger mt-2 mb-2'>メモ内容を入力してください</div>
+        <div class='alert alert-danger mt-2 mb-2'>メモ内容を入力してください</div>
         @enderror
         @foreach($tags as $tag)
         <div class="form-check form-check-inline mb-3">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -93,7 +93,7 @@
                 </div>
                 <div class="col-md-4 p-0">
                     <div class="card">
-                        <div class="card-header">メモ一覧</div>
+                        <div class="card-header">メモ一覧<a href="{{route('home')}}"><i class="fas fa-plus-circle m-1"></i></a></div>
                         <div class="card-body">
                             @foreach($memos as $memo)
                             <a href="/edit/{{$memo['id']}}" class="card-text d-block">{{$memo['content']}}</a>


### PR DESCRIPTION
アイコンの追加
  メモ一覧に追加アイコンを追記
  削除ボタンをアイコンに変更
![before_11_add_plusスクリーンショット 2022-01-29 101132](https://user-images.githubusercontent.com/89558052/151641962-e808735c-28c3-4cc9-b417-e8e4198b0db6.png)
これを
![after_11_add_plussスクリーンショット 2022-01-29 101211](https://user-images.githubusercontent.com/89558052/151641990-3c59f4d7-a848-469b-ad64-b568f08817d5.png)
このように、メモ一覧の横に+ を追記

![before_11_strashスクリーンショット 2022-01-29 101310](https://user-images.githubusercontent.com/89558052/151642001-1eedcc92-bd84-40a4-8dfa-ecc921c46e12.png)
これを
![after_11_strashスクリーンショット 2022-01-29 101348](https://user-images.githubusercontent.com/89558052/151642011-0cfbed30-f862-4937-a58d-d12e39d81ba7.png)
ごみ箱のアイコンを追加し
![after_11_strash_onlyスクリーンショット 2022-01-29 101740](https://user-images.githubusercontent.com/89558052/151642014-b10b029e-5761-4d3d-bdff-f1d3876384b7.png)
アイコンのみに変更する
