### PR TITLE
12 追加CSSで全体のレイアウトを整える

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -1,0 +1,9 @@
+.my-card-body {
+  height: calc(100vh - (55px + 48px));
+}
+
+.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -2,21 +2,21 @@
 @section('content')
 <div class="card">
     <div class="card-header">新規メモ作成</div>
-    <form class="card-body" action="{{route('store')}}" method="POST">
+    <form class="card-body my-card-body" action="{{route('store')}}" method="POST">
         @csrf
         <div class="form-group">
             <textarea class="form-control" name="content" rows="3" placeholder="ここにメモを入力"></textarea>
         </div>
         @error('content')
-            <div class='alert alert-danger mt-2 mb-2'>メモ内容を入力してください</div>
+        <div class='alert alert-danger mt-2 mb-2'>メモ内容を入力してください</div>
         @enderror
         @foreach($tags as $tag)
-            <div class="form-check form-check-inline mb-3">
-                <input type="checkbox" class="form-check-input" name="tags[]" id="{{$tag['id']}}" value="{{$tag['id']}}">
-                <label for="{{$tag['id']}}" class="form-check-label">
-                    {{$tag['name']}}
-                </label>
-            </div>
+        <div class="form-check form-check-inline mb-3">
+            <input type="checkbox" class="form-check-input" name="tags[]" id="{{$tag['id']}}" value="{{$tag['id']}}">
+            <label for="{{$tag['id']}}" class="form-check-label">
+                {{$tag['name']}}
+            </label>
+        </div>
         @endforeach
         <input type="text" class="form-control w-50 mt-3 mb-2" name="new_tag" placeholder="新しいタグを入力">
         <button type="submit" class="btn btn-primary mt-3">保存</button>

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -4,17 +4,17 @@
 @endsection
 @section('content')
 <div class="card">
-    <div class="card-header">
+    <div class="card-header d-flex justify-content-between">
         メモ編集
-        <form class="card-body" id="delete-form" action="{{route('destroy')}}" method="POST">
+        <form id="delete-form" action="{{route('destroy')}}" method="POST">
             @csrf
-            <input type="hidden" name="memo_id" value="{{$edit_memo[0]['id']}}">
-            <i class="fas fa-trash" onclick="deleteHandle(event);"></i>
+            <input type="hidden" name="memo_id" value="{{$edit_memo[0]['id']}}" />
+            <i class="fas fa-trash me-3" onclick="deleteHandle(event);"></i>
         </form>
     </div>
-    <form class="card-body" action="{{route('update')}}" method="POST">
+    <form class="card-body my-card-body" action="{{route('update')}}" method="POST">
         @csrf
-        <input type="hidden" name="memo_id" value="{{$edit_memo[0]['id']}}">
+        <input type="hidden" name="memo_id" value="{{$edit_memo[0]['id']}}" />
         <div class="form-group">
             <textarea class="form-control" name="content" rows="3" placeholder="ここにメモを入力">
             {{$edit_memo[0]['content']}}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,6 +21,7 @@
     <!-- Styles -->
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
     <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css" integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p" crossorigin="anonymous" />
+    <link href="/css/layout.css" rel="stylesheet">
 </head>
 
 <body>
@@ -80,23 +81,23 @@
         <!-- 3カラムに変更 -->
         <main class="">
             <div class="row">
-                <div class="col-md-2 p-0">
+                <div class="col-sm-12 col-md-2 p-0">
                     <div class="card">
                         <div class="card-header">タグ一覧</div>
-                        <div class="card-body">
-                            <a href="/" class="card-text d-block">全て表示</a>
+                        <div class="card-body my-card-body">
+                            <a href="/" class="card-text d-block mb-2">全て表示</a>
                             @foreach($tags as $tag)
-                            <a href="/?tag={{$tag['id']}}" class="card-text d-block">{{$tag['name']}}</a>
+                            <a href="/?tag={{$tag['id']}}" class="card-text d-block ellipsis mb-2">{{$tag['name']}}</a>
                             @endforeach
                         </div>
                     </div>
                 </div>
-                <div class="col-md-4 p-0">
+                <div class="col-sm-12 col-md-4 p-0">
                     <div class="card">
-                        <div class="card-header">メモ一覧<a href="{{route('home')}}"><i class="fas fa-plus-circle m-1"></i></a></div>
-                        <div class="card-body">
+                        <div class="card-header d-flex justify-content-between">メモ一覧<a href="{{route('home')}}"><i class="fas fa-plus-circle"></i></a></div>
+                        <div class="card-body my-card-body">
                             @foreach($memos as $memo)
-                            <a href="/edit/{{$memo['id']}}" class="card-text d-block">{{$memo['content']}}</a>
+                            <a href="/edit/{{$memo['id']}}" class="card-text d-block ellipsis mb-2">{{$memo['content']}}</a>
                             @endforeach
                         </div>
                     </div>


### PR DESCRIPTION
public/css/layout.cssを作成し、レイアウトを整える
  各カラムの余白を画面最大まで拡大
  一覧に長文があった場合、表示を省略させる
  一覧の上下余白をme-2とする

![after_12_edit_cssスクリーンショット 2022-01-29 152339](https://user-images.githubusercontent.com/89558052/151650361-b3756b2f-e680-45c9-a8ba-c87a8fea55dd.png)
